### PR TITLE
move HTML into HBS file from helpers.js

### DIFF
--- a/web/helpers.js
+++ b/web/helpers.js
@@ -100,14 +100,6 @@ handlebars.registerHelper("resourceTypes", () => {
     return process.resourceTypes;
 });
 // for use in the addOrEdit.hbs resource referrals and fails
-handlebars.registerHelper("alertFails", (dict, total) => {
-    if(!dict) return ""
-    var output = "alert('Total Referrals: " + handlebars.escapeExpression(total) + "\\n";
-    for (var key of Object.keys(dict)) {
-        output += handlebars.escapeExpression(key) + ": " + handlebars.escapeExpression(dict[key]) + "\\n";
-    }
-    return new handlebars.SafeString(output + "')");
-});
 handlebars.registerHelper("stateConvert", (state)  =>{
     if (state == null) {
         return new handlebars.SafeString('TX');
@@ -115,10 +107,6 @@ handlebars.registerHelper("stateConvert", (state)  =>{
     return new handlebars.SafeString(states[state]);
 });
 // for use in the list.hbs additional resource hyperlinks
-handlebars.registerHelper("resourceLinks", (str) => {
-    var links = "";
-    str.split('\n').forEach(element => {
-        links += "<a href=\"" + handlebars.escapeExpression(element) + "\">" + handlebars.escapeExpression(element) + "</a>";
-    });
-    return new handlebars.SafeString(links);
-})
+handlebars.registerHelper("split", (str) => {
+    return str.split('\n');
+});

--- a/web/views/resource/addOrEdit.hbs
+++ b/web/views/resource/addOrEdit.hbs
@@ -6,12 +6,19 @@
 {{/if}}
 <div style="padding:5px ">
     {{#if resource}}
-        <a href="uploads/{{resource._id}}"><button type="submit" class="btn btn-secondary"
-                style="position: absolute; right: 15px; top: 17px;"><i class="fa fa-archive"></i> View
-                Attachments</button></a>
-        <button onclick="{{alertFails resource.resourceReferralFails resource.resourceReferrals}}" class="btn btn-secondary"
-            style="position: absolute; right: 15px; top: 87px;"><i class="fa fa-minus-circle"></i> View Referral
-            Failures</button>
+        <a href="uploads/{{resource._id}}">
+            <button type="submit" class="btn btn-secondary"
+                style="position: absolute; right: 15px; top: 17px;"
+                ><i class="fa fa-archive"></i> View Attachments
+            </button>
+        </a>
+        <button onclick='alert("Total Referrals: {{resource.resourceReferrals}}
+            {{~#each resource.resourceReferralFails~}}
+            	\n{{@key}}: {{this}}
+            {{~/each~}}
+            ");' class="btn btn-secondary" style="position: absolute; right: 15px; top: 87px;"
+            ><i class="fa fa-minus-circle"></i> View Referral Failures
+        </button>
     {{/if}}
     <form action="/resource" method="POST" autocomplete="off">
         <input type="hidden" name="_id" value="{{resource._id}}">

--- a/web/views/resource/list.hbs
+++ b/web/views/resource/list.hbs
@@ -66,7 +66,9 @@
                     <a href="{{this.resourceWebsite}}">{{this.resourceWebsite}}</a>
                 </td>
                 <td>
-                    {{resourceLinks this.resourceLink}}
+                    {{#each (split this.resourceLink "\n")}}
+                        <a href="{{this}}">{{this}}</a>
+                    {{/each}}
                 </td>
                 <td>{{this.resourceReferrals}}</td>
                 <td>{{this.resourceSuccessPercent}}</td>


### PR DESCRIPTION
In preparation for document changes, this will simplify feature parity efforts by reducing dependency on the exact structure of the document within Handlebars helpers.